### PR TITLE
change mac bundles name

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,6 +87,7 @@ jobs:
         rm -f dist/${{ matrix.TARGET }}/${{ matrix.APP_BINARY_FILE_NAME }}
         cd dist/${{ matrix.TARGET }}
         tar -cvf ${{ matrix.BUNDLE_NAME }}.tar ${{ matrix.OUT_FILE_NAME }}
+        
     - name: Upload artifact
       if: matrix.TARGET != 'macos'
       uses: actions/upload-artifact@v4
@@ -98,7 +99,7 @@ jobs:
       if: matrix.TARGET == 'macos'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.BUNDLE_NAME }}
+        name: ${{ matrix.BUNDLE_NAME }}.tar
         path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar
     
     - name: Upload binaries to release


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Create a tar archive of the macOS bundle before uploading it as an artifact.