### PR TITLE
Update python versions

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3']
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Install App and Extras
       run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -64,7 +64,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Install dependencies and build
       run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Build dist files
         run: |
           python --version

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.x']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3']
+        python-version: ["3.9", "3.11", "3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tabcmd = ["tabcmd.locales/**/*.mo"]
 [tool.black]
 line-length = 120
 required-version = 22
-target-version = ['py39', 'py310', 'py311', 'py312', 'py312']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 extend-exclude = '^/bin/*'
 [tool.mypy]
 disable_error_code = [
@@ -37,8 +37,8 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11"
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tabcmd = ["tabcmd.locales/**/*.mo"]
 [tool.black]
 line-length = 120
 required-version = 22
-target-version = ['py39', 'py310', 'py311', 'py313'] # black doesn't like 3.12
+target-version = ['py39', 'py310', 'py311'] # have to upgrade black to run on later versions
 extend-exclude = '^/bin/*'
 [tool.mypy]
 disable_error_code = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ classifiers = [
 ]
 dependencies = [
     "appdirs",
+    "doit",
+    "ftfy",
     "pyinstaller_versionfile",
+    "pytest-order",
     "requests>=2.25,<3.0",
     "setuptools_scm",
     "types-appdirs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tabcmd = ["tabcmd.locales/**/*.mo"]
 [tool.black]
 line-length = 120
 required-version = 22
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py313'] # black doesn't like 3.12
 extend-exclude = '^/bin/*'
 [tool.mypy]
 disable_error_code = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tabcmd = ["tabcmd.locales/**/*.mo"]
 [tool.black]
 line-length = 120
 required-version = 22
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py312']
 extend-exclude = '^/bin/*'
 [tool.mypy]
 disable_error_code = [
@@ -31,21 +31,19 @@ description="A command line client for working with Tableau Server."
 authors = [{name="Tableau", email="github@tableau.com"}]
 license = {file = "LICENSE"}
 readme = "res/README.md"
-requires-python = ">=3.7"  # https://devguide.python.org/versions/
+requires-python = ">=3.9"  # https://devguide.python.org/versions/
 classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11"
+  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
     "appdirs",
-    "doit",
-    "ftfy",
     "pyinstaller_versionfile",
-    "pytest-order",
     "requests>=2.25,<3.0",
     "setuptools_scm",
     "types-appdirs",

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -386,6 +386,12 @@ class OnlineCommandTest(unittest.TestCase):
         self._get_view(wb_name_on_server, sheet_name + ".csv")
 
     @pytest.mark.order(11)
+    def test_view_get_png(self):
+        wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
+        sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
+        self._get_view(wb_name_on_server, sheet_name + ".png")
+
+    @pytest.mark.order(11)
     def test_wb_publish_embedded(self):
         file = os.path.join("tests", "assets", OnlineCommandTest.TWB_WITH_EMBEDDED_CONNECTION)
         arguments = self._publish_args(file, OnlineCommandTest.EMBEDDED_TWB_NAME)


### PR DESCRIPTION
- use 3.12 as target
- have action workflows target 3.9 - 3.13

## Summary by Sourcery

Update Python versions to 3.9-3.13 and set the target version to 3.12.

Build:
- Update Python target version to 3.12.

CI:
- Update CI workflows to use Python 3.9, 3.10, 3.11, 3.12, and 3.13.