### PR TITLE
docs: consolidate repeated global options into Jekyll include

### DIFF
--- a/_includes/global-options.md
+++ b/_includes/global-options.md
@@ -1,0 +1,45 @@
+The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
+
+-h, \-\-help
+
+: Displays the help for the command.
+
+<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
+
+-s, \-\-server
+
+: The Tableau Online URL, which is required at least once to begin session.
+
+-u, \-\-user
+
+: The Tableau Online username, which is required at least once to begin session.
+
+-p, \-\-password
+
+: The Tableau Online password, which is required at least once to begin session.
+
+\-\-password-file
+
+: Allows the password to be stored in the given .txt file rather than the command line for increased security.
+
+-t, \-\-site
+
+: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
+
+\-\-no-prompt
+
+: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
+
+\-\-[no-]cookie
+
+: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
+
+\-\-timeout
+
+: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
+
+\-\-
+
+: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
+
+```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```

--- a/docs/tabcmd_cmd.md
+++ b/docs/tabcmd_cmd.md
@@ -63,51 +63,7 @@ Creates extracts for a published workbook or data source.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # creategroup *group-name*
@@ -119,51 +75,7 @@ Creates a group. Use addusers to add users after the group has been created.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-    ```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 
@@ -193,51 +105,7 @@ Creates a project.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 # createsiteusers *filename.csv*
 
@@ -298,51 +166,7 @@ The default is Unlicensed for new users and unchanged for existing users. Users 
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # delete workbook-name or datasource-name
@@ -375,51 +199,7 @@ This command takes the name of the workbook or data source as it is on the serve
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # deleteextracts
@@ -458,51 +238,7 @@ Deletes extracts for a published workbook or data source.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # deletegroup *group-name*
@@ -514,51 +250,7 @@ Deletes the specified group from the server.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # deleteproject *project-name*
@@ -580,51 +272,7 @@ Using tabcmd, you can specify only a top-level project in a project hierarchy. T
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # deletesiteusers *filename.csv*
@@ -640,51 +288,7 @@ If the user owns content, the user's role is change to **Unlicensed**, but the u
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # export
@@ -800,51 +404,7 @@ Sets the height in pixels. Default is 600 px.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 # get *url*
 Gets the resource from Tableau Online that's represented by the specified (partial) URL. The result is returned as a file.
@@ -897,51 +457,7 @@ You can optionally add the URL parameter ?:refresh=yes to force a fresh data que
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # login
@@ -1035,51 +551,7 @@ The site ID is used in the URL to uniquely identify the site. For example, a sit
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # logout
@@ -1186,51 +658,7 @@ If you want to schedule extract refreshes after publishing, you must include thi
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # refreshextracts *workbook-name* or *datasource-name*
@@ -1312,51 +740,7 @@ For example:
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # removeusers *group-name*
@@ -1380,51 +764,7 @@ Removes users from the specified group.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 
 # runschedule *schedule-name*
@@ -1442,50 +782,6 @@ This command is not available for Tableau Online.
 
 ## Global options
 
-The following options are used by all tabcmd commands. The `--server`, `--user`, and `--password` options are required at least once to begin a session. An authentication token is stored so subsequent commands can be run without including these options. This token remains valid for five minutes after the last command that used it.
-
--h, \-\-help
-
-: Displays the help for the command.
-
-<div class="alert alert-info"><strong>Note</strong>: Some commands listed may not apply when using tabcmd with Tableau Online.</div>
-
--s, \-\-server
-
-: The Tableau Online URL, which is required at least once to begin session.
-
--u, \-\-user
-
-: The Tableau Online username, which is required at least once to begin session.
-
--p, \-\-password
-
-: The Tableau Online password, which is required at least once to begin session.
-
-\-\-password-file
-
-: Allows the password to be stored in the given .txt file rather than the command line for increased security.
-
--t, \-\-site
-
-: Indicates that the command applies to the site specified by the Tableau Online site ID, surrounded by single quotes or double quotes. Use this option if the user specified is associated with more than one site. Site ID is case-sensitive when using a cached authentication token. If you do not match case you may be prompted for a password even if the token is still valid.
-
-\-\-no-prompt
-
-: When specified, the command will not prompt for a password. If no valid password is provided the command will fail.
-
-\-\-[no-]cookie
-
-: When specified, the session ID is saved on login so subsequent commands will not need to log in. Use the no- prefix to not save the session ID. By default, the session is saved.
-
-\-\-timeout
-
-: Waits the specified number of seconds for the server to complete processing the command. By default, the process will wait until the server responds.
-
-\-\-
-
-: Specifies the end of options on the command line. You can use \-\- to indicate to tabcmd that anything that follows \-\- should not be interpreted as an option setting and can instead be interpreted as a value for the command. This is useful if you need to specify a value in the command that includes a hyphen. The following example shows how you might use \-\- in a tabcmd command, where -430105/Sheet1 is a required value for the export command.
-
-```tabcmd export --csv -f "D:\export10.csv" -- -430105/Sheet1```
+{% include global-options.md %}
 
 


### PR DESCRIPTION
Preview PR for tableau/tabcmd#401.

Extracts the global options block (repeated 16 times) into `_includes/global-options.md` and replaces each copy with `{% include global-options.md %}`. Content is unchanged.

Preview at https://jacalata.github.io/tabcmd once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate the repeated tabcmd global options documentation into a single reusable include.

Enhancements:
- Refactor tabcmd command documentation to use a shared Jekyll include for the global options section, reducing duplication and easing future maintenance.

Documentation:
- Add a `_includes/global-options.md` partial and reference it from all tabcmd command sections without changing the documented behavior or options.